### PR TITLE
[fix] textField 수정

### DIFF
--- a/pp/pp/View/Community/PostReplyView.swift
+++ b/pp/pp/View/Community/PostReplyView.swift
@@ -111,10 +111,12 @@ struct PostReplyView: View {
                 vm.loadComments(postId: self.postId, lastId: nil)
             }
             .onAppear {
+                vm.newComment = ""
                 setupKeyboardObservers()
             }
             .onDisappear {
                 removeKeyboardObservers()
+                vm.newComment = ""
             }
             .alert("이 댓글을 신고하시겠습니까?", isPresented: $showAlert) {
                            Button("예", role: .destructive) {


### PR DESCRIPTION
- UITextField  댓글 작성 중 버튼 안누르고 뒤로가기 하면 작성중이던 내용 다른 화면에도 계속 남아있는 버그 수정 